### PR TITLE
Improved handling of multiline changesets, which previously would produce invalid bullet points.

### DIFF
--- a/.changeset/red-poets-heal.md
+++ b/.changeset/red-poets-heal.md
@@ -1,0 +1,7 @@
+---
+"changesets": minor
+---
+
+Improved handling of multiline changesets, which previously would produce invalid bullet points.
+
+This change also introduces a Markdown formatter function to clean up any easily fixed formatting issues.

--- a/.editorconfig
+++ b/.editorconfig
@@ -494,3 +494,6 @@ ij_yaml_space_before_colon = false
 ij_yaml_spaces_within_braces = true
 ij_yaml_spaces_within_brackets = true
 
+[*.md]
+indent_size = 2
+indent_style = space

--- a/changesets-java/pom.xml
+++ b/changesets-java/pom.xml
@@ -51,6 +51,10 @@
             <groupId>org.codehaus.mojo.versions</groupId>
             <artifactId>versions-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-all</artifactId>
+        </dependency>
 
 
         <dependency>
@@ -85,6 +89,20 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.hosuaby</groupId>
+            <artifactId>inject-resources-core</artifactId>
+            <version>0.3.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.hosuaby</groupId>
+            <artifactId>inject-resources-junit-jupiter</artifactId>
+            <version>0.3.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/changesets-java/src/main/java/se/fortnox/changesets/MarkdownFormatter.java
+++ b/changesets-java/src/main/java/se/fortnox/changesets/MarkdownFormatter.java
@@ -1,0 +1,37 @@
+package se.fortnox.changesets;
+
+import com.vladsch.flexmark.formatter.Formatter;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import com.vladsch.flexmark.util.sequence.LineAppendable;
+
+import static com.vladsch.flexmark.formatter.Formatter.FORMAT_FLAGS;
+import static com.vladsch.flexmark.formatter.Formatter.RIGHT_MARGIN;
+import static com.vladsch.flexmark.util.data.SharedDataKeys.BLANK_LINES_IN_AST;
+
+public class MarkdownFormatter {
+    /**
+     * Format a Markdown document for consistency.
+     *
+     * @param markdown The unformatted Markdown document
+     * @return The formatted Markdown document
+     */
+	public static String format(String markdown) {
+		MutableDataSet formatOptions = new MutableDataSet();
+		// Clean up whitespaces in different ways
+		formatOptions.set(FORMAT_FLAGS, LineAppendable.F_FORMAT_ALL);
+
+        // Limit line lengths
+		formatOptions.set(RIGHT_MARGIN, 120);
+
+        // Leaving this on false adds new lines in strange places, unsure why
+		formatOptions.set(BLANK_LINES_IN_AST, true);
+
+		Formatter formatter = Formatter.builder(formatOptions).build();
+		Parser parser = Parser.builder().build();
+		Document parsed = parser.parse(markdown);
+
+        return formatter.render(parsed);
+	}
+}

--- a/changesets-java/src/test/java/se/fortnox/changesets/ChangelogAggregatorTest.java
+++ b/changesets-java/src/test/java/se/fortnox/changesets/ChangelogAggregatorTest.java
@@ -1,5 +1,6 @@
 package se.fortnox.changesets;
 
+import com.google.common.base.Strings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -12,9 +13,7 @@ import java.nio.file.StandardOpenOption;
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.fortnox.changesets.ChangelogAggregator.CHANGELOG_FILE;
 
-
 class ChangelogAggregatorTest {
-
 	public static final String PACKAGE_NAME = "my-package";
 
 	@Test
@@ -37,14 +36,14 @@ class ChangelogAggregatorTest {
 			.content()
 			.isEqualTo("""
 				# my-package
-
+				
 				## 1.0.0
-
+				
 				### Patch Changes
-
+				
 				- Hello!
+				
 				""");
-
 	}
 
 	@Test
@@ -52,8 +51,8 @@ class ChangelogAggregatorTest {
 		ChangelogAggregator changelog = new ChangelogAggregator(tempDir);
 
 		ChangesetWriter changesetWriter = new ChangesetWriter(tempDir);
-		changesetWriter.writeChangeset(PACKAGE_NAME, Level.PATCH, "Lorem ipsum dolor sit amet");
-		changesetWriter.writeChangeset(PACKAGE_NAME, Level.PATCH, "Consectetur adipiscing elit");
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.PATCH, "Lorem ipsum   dolor sit amet");
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.PATCH, "Consectetur  adipiscing elit");
 		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "Sed aliquam diam eget arcu iaculis imperdiet");
 		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "Curabitur rhoncus urna convallis");
 		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MINOR, "Donec lobortis sodales posuere");
@@ -89,6 +88,7 @@ class ChangelogAggregatorTest {
 				
 				- Consectetur adipiscing elit
 				- Lorem ipsum dolor sit amet
+				
 				""");
 	}
 
@@ -120,11 +120,11 @@ class ChangelogAggregatorTest {
 	void shouldAppendToExistingChangelog(@TempDir Path tempDir) throws IOException {
 		var existingChangeLogContent = """
 			# my-package
-
+			
 			## 1.0.0
-
+			
 			### Patch Changes
-
+			
 			- Existing entry
 			""";
 
@@ -148,18 +148,112 @@ class ChangelogAggregatorTest {
 			.content()
 			.isEqualTo("""
 				# my-package
-  
+				
 				## 1.0.1
 				
 				### Patch Changes
 				
 				- Hello!
 				
+				
 				## 1.0.0
 				
 				### Patch Changes
 				
 				- Existing entry
+				""");
+	}
+
+	@Test
+	void shouldIndentEachChange(@TempDir Path tempDir) throws FileAlreadyExistsException {
+		ChangelogAggregator changelog = new ChangelogAggregator(tempDir);
+
+		ChangesetWriter changesetWriter = new ChangesetWriter(tempDir);
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, """
+			Bullet list:
+			- A bullet point
+			- Another bullet point
+			  - Sub bullet
+			  - Sub bullet 3
+			- Third bullet
+			""");
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "Hello friend");
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, """
+			One line
+			
+			Another line
+			""");
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "Why hello!");
+
+		assertThat(tempDir.resolve(ChangesetWriter.CHANGESET_DIR))
+			.exists()
+			.isDirectory()
+			.isDirectoryContaining(path -> path.toFile().getName().endsWith(".md"));
+
+		changelog.mergeChangesetsToChangelog(PACKAGE_NAME, "1.0.0");
+
+		assertThat(tempDir.resolve(CHANGELOG_FILE))
+			.exists()
+			.isRegularFile()
+			.content()
+			.isEqualTo("""
+				# my-package
+				
+				## 1.0.0
+				
+				### Major Changes
+				
+				- Bullet list:
+				  - A bullet point
+				  - Another bullet point
+				    - Sub bullet
+				    - Sub bullet 3
+				  - Third bullet
+				- Hello friend
+				- One line
+				
+				  Another line
+				- Why hello!
+				
+				""");
+	}
+
+	@Test
+	void shouldFormatMarkdown(@TempDir Path tempDir) throws FileAlreadyExistsException {
+		ChangelogAggregator changelog = new ChangelogAggregator(tempDir);
+
+		ChangesetWriter changesetWriter = new ChangesetWriter(tempDir);
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "A change with  too    many  spaces");
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "A change\nwith multiple\n lines.");
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "A change with a lot of words an no linebreaks " + Strings.repeat("word ", 30));
+		changesetWriter.writeChangeset(PACKAGE_NAME, Level.MAJOR, "Bullet list:\n  - A bullet point\n  - Another bullet point");
+
+		assertThat(tempDir.resolve(ChangesetWriter.CHANGESET_DIR))
+			.exists()
+			.isDirectory()
+			.isDirectoryContaining(path -> path.toFile().getName().endsWith(".md"));
+
+		changelog.mergeChangesetsToChangelog(PACKAGE_NAME, "1.0.0");
+
+		assertThat(tempDir.resolve(CHANGELOG_FILE))
+			.exists()
+			.isRegularFile()
+			.content()
+			.isEqualTo("""
+				# my-package
+				
+				## 1.0.0
+				
+				### Major Changes
+				
+				- A change with multiple lines.
+				- A change with too many spaces
+				- A change with a lot of words an no linebreaks word word word word word word word word word word word word word word
+				  word word word word word word word word word word word word word word word word
+				- Bullet list:
+				  - A bullet point
+				  - Another bullet point
+				
 				""");
 	}
 }

--- a/changesets-java/src/test/java/se/fortnox/changesets/MarkdownFormatterTest.java
+++ b/changesets-java/src/test/java/se/fortnox/changesets/MarkdownFormatterTest.java
@@ -1,0 +1,22 @@
+package se.fortnox.changesets;
+
+import com.adelean.inject.resources.junit.jupiter.GivenTextResource;
+import com.adelean.inject.resources.junit.jupiter.TestWithResources;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestWithResources
+class MarkdownFormatterTest {
+    @GivenTextResource("markdown-tests/formatter.original.md")
+    String original;
+
+    @GivenTextResource("markdown-tests/formatter.expected.md")
+    String expected;
+
+    @Test
+    void shouldFormatDocumentAsExpected() {
+        assertThat(MarkdownFormatter.format(original)).isEqualTo(expected);
+    }
+
+}

--- a/changesets-java/src/test/resources/markdown-tests/formatter.expected.md
+++ b/changesets-java/src/test/resources/markdown-tests/formatter.expected.md
@@ -1,0 +1,19 @@
+# my-package
+
+## 1.0.0
+
+### Major Changes
+
+- Bullet list:
+  - A bullet point
+  - Another bullet point
+    - Sub bullet
+    - Sub bullet 3
+  - Third bullet
+- First line Second line Third line
+- Hello friend
+- One line
+
+  Another line
+- Why hello!
+

--- a/changesets-java/src/test/resources/markdown-tests/formatter.original.md
+++ b/changesets-java/src/test/resources/markdown-tests/formatter.original.md
@@ -1,0 +1,20 @@
+# my-package
+
+## 1.0.0
+
+### Major Changes
+
+- Bullet list:
+  - A bullet point
+  - Another bullet point
+    - Sub bullet
+    - Sub bullet 3
+  - Third bullet
+- First line
+  Second line
+  Third line
+- Hello friend
+- One line
+
+  Another line
+- Why hello!

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,11 @@
                 <artifactId>versions-common</artifactId>
                 <version>2.17.1</version>
             </dependency>
-
-
+            <dependency>
+                <groupId>com.vladsch.flexmark</groupId>
+                <artifactId>flexmark-all</artifactId>
+                <version>0.64.8</version>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>


### PR DESCRIPTION
This change also introduces a Markdown formatter function to clean up any easily fixed formatting issues.

There is currently only a single test document for the formatter to get a decent baseline, but more should be added as we tweak the formatting options.