### PR TITLE
Fix maven-central-publish action

### DIFF
--- a/.github/workflows/maven-central-publish.yml
+++ b/.github/workflows/maven-central-publish.yml
@@ -1,8 +1,7 @@
 name: Publish package to the Maven Central Repository
-on:
+
 # TODO This trigger should be automated to match merging release-PRs later on
-#  release:
-#    types: [created]
+on:
   workflow_dispatch
 
 jobs:
@@ -20,10 +19,13 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - name: Set version
       - name: Publish package
+        # First install the artifact to make it available for use by the project
+        # Then prepare for release using changesets:release
+        # Finally deploy to Maven Central
         run: |
-          ./mvnw --batch-mode --no-transfer-progress changesets:release
+          ./mvnw --batch-mode --no-transfer-progress install
+          ./mvnw --batch-mode --no-transfer-progress se.fortnox.changesets:changesets-maven-plugin:release
           ./mvnw --batch-mode --no-transfer-progress -Ppublish deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pom.xml
+++ b/pom.xml
@@ -236,16 +236,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-        </plugins>
     </build>
 
     <profiles>


### PR DESCRIPTION
This can be further improved later on by chaining it together with the other release steps, such as changesets:prepare and the merging of release-PRs. For now it is manually run and requires a final publishing step inside the new Maven Central portal.