### PR TITLE
Set up Maven Central publishing as a Github Deployment

### DIFF
--- a/.github/workflows/maven-central-publish.yml
+++ b/.github/workflows/maven-central-publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: central
     steps:
       - uses: actions/checkout@v4
       - name: Set up Maven Central Repository


### PR DESCRIPTION
Allows for using deployments in Github, which both shows as deployments and can use features like branch limitations and approvals.

Tested and run with modified configuration that allowed deploying from this branch already :)