### PR TITLE
Add parameters for generating more flexible changesets using the add goal

### DIFF
--- a/.github/workflows/dependabot-changesets.yml
+++ b/.github/workflows/dependabot-changesets.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'FortnoxAB/changesets-java'
     steps:
       - name: Dependabot metadata
-        id: metadata
+        id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2
         with:
           skip-verification: true
@@ -22,4 +22,8 @@ jobs:
         run: |
             echo "dependency-names: ${{ steps.dependabot-metadata.outputs.dependency-names }}"
             echo "new-version: ${{ steps.dependabot-metadata.outputs.new-version }}"
-            echo "${{ toJSON(steps.metadata.outputs) }}"
+            echo "${{ toJSON(steps.dependabot-metadata.outputs) }}"
+          
+            # Fake adding a changeset so we see that it runs with the correct parameters
+            echo "./mvnw se.fortnox.changesets:changesets-maven-plugin:add -DchangesetLevel=dependency -DchangesetContent=\"- ${{ steps.dependabot-metadata.outputs.dependency-names }}: ${{ steps.dependabot-metadata.outputs.new-version }}\""
+          

--- a/changesets-maven-plugin/pom.xml
+++ b/changesets-maven-plugin/pom.xml
@@ -168,6 +168,8 @@
 							<settingsFile>src/it/settings.xml</settingsFile>
 							<addTestClassPath>true</addTestClassPath>
 							<showErrors>true</showErrors>
+							<!-- Skip these when skipping tests -->
+							<skipInvocation>${skipTests}</skipInvocation>
 							<goals>
 								<goal>clean</goal>
 								<goal>test-compile</goal>

--- a/changesets-maven-plugin/src/it/add-changeset-from-property/invoker.properties
+++ b/changesets-maven-plugin/src/it/add-changeset-from-property/invoker.properties
@@ -1,1 +1,8 @@
-invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:add -DchangesetContent='thecontent'
+# changesetFilename is used to get predictable names for the changesets, so testing is easier
+
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:add -DchangesetContent='Patch change' -DchangesetLevel=Patch -DchangesetFilename=patch.md
+invoker.goals.2=${project.groupId}:${project.artifactId}:${project.version}:add -DchangesetContent='Minor change' -DchangesetLevel=MINOR -DchangesetFilename=minor.md
+invoker.goals.3=${project.groupId}:${project.artifactId}:${project.version}:add -DchangesetContent='Major change' -DchangesetLevel=major -DchangesetFilename=major.md
+
+# TODO Enable this goal to test the dependency change, once that PR is merged
+# invoker.goals.4=${project.groupId}:${project.artifactId}:${project.version}:add -DchangesetContent='Dependency change' -DchangesetLevel=Dependency -DchangesetFilename=dependency.md

--- a/changesets-maven-plugin/src/it/add-changeset-from-property/verify.groovy
+++ b/changesets-maven-plugin/src/it/add-changeset-from-property/verify.groovy
@@ -1,11 +1,32 @@
-// Verify that exactly one markdown file was added to the .changeset folder and has the expected content
-def firstChangeset = new File(basedir, ".changeset")
+def changesetFiles = new File(basedir, ".changeset")
         .listFiles()
         .findAll { it.name ==~ /.*\.md/ }
-        .first()
+assert changesetFiles.size() == 3
 
-assert firstChangeset.text.equals("---\n" +
+
+assert new File(basedir, ".changeset/patch.md").text.equals("---\n" +
         "\"add-blank-changelog\": patch\n" +
         "---\n" +
         "\n" +
-        "thecontent");
+        "Patch change");
+
+assert new File(basedir, ".changeset/minor.md").text.equals("---\n" +
+        "\"add-blank-changelog\": minor\n" +
+        "---\n" +
+        "\n" +
+        "Minor change");
+
+assert new File(basedir, ".changeset/major.md").text.equals("---\n" +
+        "\"add-blank-changelog\": major\n" +
+        "---\n" +
+        "\n" +
+        "Major change");
+
+// See invoker.properties for the dependency change details
+/*
+assert new File(basedir, ".changeset/dependency.md").text.equals("---\n" +
+        "\"add-blank-changelog\": dependency\n" +
+        "---\n" +
+        "\n" +
+        "Dependency change");
+*/

--- a/changesets-maven-plugin/src/main/java/se/fortnox/changesets/maven/AddMojo.java
+++ b/changesets-maven-plugin/src/main/java/se/fortnox/changesets/maven/AddMojo.java
@@ -8,16 +8,37 @@ import se.fortnox.changesets.Changeset;
 import se.fortnox.changesets.ChangesetWriter;
 import se.fortnox.changesets.Level;
 
+import java.io.File;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static se.fortnox.changesets.ChangesetWriter.CHANGESET_DIR;
 
 @Mojo(name = "add", defaultPhase = LifecyclePhase.INITIALIZE, aggregator = true)
 public class AddMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project}", readonly = true, required = true)
 	private org.apache.maven.project.MavenProject project;
 
+	/**
+	 * Default content of the changeset.
+	 */
 	@Parameter(property = "changesetContent")
 	String changesetContent;
+
+	/**
+	 * Level of the changeset, e.g. patch, minor, major.
+	 */
+	@Parameter(property = "changesetLevel", defaultValue = "patch")
+	String changesetLevel;
+
+	/**
+	 * Create the changeset with a specific filename.
+	 * By default, a filename will be automatically generated.
+	 */
+	@Parameter(property = "changesetFilename")
+	String changesetFilename;
 
 	@Override
 	public void execute() {
@@ -25,8 +46,22 @@ public class AddMojo extends AbstractMojo {
 
 		ChangesetWriter changesetWriter = new ChangesetWriter(baseDir);
 
+		Level level;
 		try {
-			var changeset = new Changeset("%s".formatted(project.getArtifactId()), Level.PATCH, changesetContent, null);
+			level = Level.valueOf(this.changesetLevel.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			List<String> validLevels = Arrays.stream(Level.values()).map(Enum::name).toList();
+			getLog().error("Invalid changeset level: %s. Valid values are: %s".formatted(this.changesetLevel, validLevels));
+			return;
+		}
+
+		File changesetFile = null;
+		if (changesetFilename != null && !changesetFilename.isBlank()) {
+			changesetFile = baseDir.resolve(CHANGESET_DIR).resolve(changesetFilename).toFile();
+		}
+
+		try {
+			var changeset = new Changeset("%s".formatted(project.getArtifactId()), level, changesetContent, changesetFile);
 			changesetWriter.writeChangeset(changeset);
 		} catch (FileAlreadyExistsException e) {
 			throw new RuntimeException(e);

--- a/changesets-maven-plugin/src/main/java/se/fortnox/changesets/maven/AddMojo.java
+++ b/changesets-maven-plugin/src/main/java/se/fortnox/changesets/maven/AddMojo.java
@@ -61,7 +61,7 @@ public class AddMojo extends AbstractMojo {
 		}
 
 		try {
-			var changeset = new Changeset("%s".formatted(project.getArtifactId()), level, changesetContent, changesetFile);
+			var changeset = new Changeset(project.getArtifactId(), level, changesetContent, changesetFile);
 			changesetWriter.writeChangeset(changeset);
 		} catch (FileAlreadyExistsException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
You can now create changesets with more prefilled info and with predictable names (useful for testing and dependabot).

```
mvn changesets:add -DchangesetLevel=patch -DchangesetContent="My change" -DchangesetFile=magic.md
```